### PR TITLE
Use gRPC for task scheduling.

### DIFF
--- a/api/rpc/runner/index.js
+++ b/api/rpc/runner/index.js
@@ -1,0 +1,84 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = runnerServerFactory;
+di.annotate(runnerServerFactory, new di.Provide('TaskGraph.TaskRunner.Server'));
+di.annotate(runnerServerFactory,
+    new di.Inject(
+        'Assert',
+        '_',
+        'Promise'
+    )
+);
+
+function runnerServerFactory(
+    assert,
+    _,
+    Promise
+) {
+    var grpc = require('grpc');
+
+    function RunnerServer(options) {
+        this.options = options || {
+            hostname: '0.0.0.0'
+        };
+        this.options.protoFile = this.options.protoFile || __dirname + '/../../../runner.proto';
+
+        assert.string(this.options.hostname);
+        assert.string(this.options.protoFile);
+    }
+
+    RunnerServer.prototype.start = function() {
+        var self = this;
+
+        return Promise.try(function() {
+            var runnerProto = grpc.load(self.options.protoFile).runner;
+
+            var tasks = require('./tasks.js');
+
+            self.gRPC = new grpc.Server();
+            self.gRPC.addProtoService(runnerProto.Runner.service, {
+                runTask: grpcWrapper(tasks.run),
+                cancelTask: grpcWrapper(tasks.cancel)
+            });
+
+            self.options.port = self.gRPC.bind(
+                self.options.hostname + (self.options.port ? ':' + self.options.port : ''),
+                grpc.ServerCredentials.createInsecure());
+            self.gRPC.start();
+            console.log('gRPC is available on grpc://' + self.options.hostname + ':' + self.options.port);
+        });
+    }
+
+    RunnerServer.prototype.stop = function() {
+        var self = this;
+        return Promise.try(function() {
+            self.gRPC.forceShutdown();
+        });
+    }
+
+    function grpcWrapper(rpcEntry) {
+        return function(call, callback) {
+            return Promise.try(function() {
+                return rpcEntry(call, callback);
+            })
+            .then(function(response) {
+                if(response) {
+                    callback(null, {
+                        response: JSON.stringify(response)
+                    });
+                }
+            })
+            .catch(function(err) {
+                callback(err);
+            })
+        };
+    }
+
+    return RunnerServer;
+}
+
+

--- a/api/rpc/runner/tasks.js
+++ b/api/rpc/runner/tasks.js
@@ -1,0 +1,23 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var _ = injector.get('_'); // jshint ignore:line
+var Errors = injector.get('Errors');
+var taskGraphRunner = require('../../../index.js').taskGraphRunner;
+
+var runTask = function(call) {
+    taskGraphRunner.taskRunner.runTaskStream.onNext(call.request);
+    return {};
+};
+
+var cancelTask = function(call) {
+    taskGraphRunner.taskRunner.cancelTaskStream.onNext(call.request);
+    return {};
+}
+
+module.exports = {
+    run: runTask,
+    cancel: cancelTask
+};

--- a/api/rpc/scheduler/index.js
+++ b/api/rpc/scheduler/index.js
@@ -25,7 +25,7 @@ function schedulerServerFactory(
         this.options = options || {
             hostname: '0.0.0.0'
         };
-        this.options.protoFile = this.options.protoFile || __dirname + '/../../scheduler.proto';
+        this.options.protoFile = this.options.protoFile || __dirname + '/../../../scheduler.proto';
 
         assert.string(this.options.hostname);
         assert.string(this.options.protoFile);

--- a/api/rpc/scheduler/tasks.js
+++ b/api/rpc/scheduler/tasks.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var injector = require('../../index.js').injector;
+var injector = require('../../../index.js').injector;
 var tasksApiService = injector.get('Http.Services.Api.Tasks');
 var _ = injector.get('_'); // jshint ignore:line
 var Errors = injector.get('Errors');

--- a/api/rpc/scheduler/workflowGraphs.js
+++ b/api/rpc/scheduler/workflowGraphs.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var injector = require('../../index.js').injector;
+var injector = require('../../../index.js').injector;
 var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var _ = injector.get('_');    // jshint ignore:line
 

--- a/api/rpc/scheduler/workflowTasks.js
+++ b/api/rpc/scheduler/workflowTasks.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var injector = require('../../index.js').injector;
+var injector = require('../../../index.js').injector;
 var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var _ = injector.get('_');    // jshint ignore:line
 

--- a/api/rpc/scheduler/workflows.js
+++ b/api/rpc/scheduler/workflows.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var injector = require('../../index.js').injector;
+var injector = require('../../../index.js').injector;
 var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var Errors = injector.get('Errors');
 var Constants = injector.get('Constants');

--- a/lib/task-graph-runner.js
+++ b/lib/task-graph-runner.js
@@ -69,11 +69,11 @@ function runnerFactory(
         .spread(function() {
             var startPromises = [];
             if (options.runner) {
-                self.taskRunner = TaskRunner.create({ domain: options.domain });
+                self.taskRunner = TaskRunner.create({ domain: options.domain, debug: true });
                 startPromises.push(self.taskRunner.start());
             }
             if (options.scheduler) {
-                self.taskScheduler = TaskScheduler.create({ domain: options.domain });
+                self.taskScheduler = TaskScheduler.create({ domain: options.domain, debug: true});
                 startPromises.push(self.taskScheduler.start());
                 self.completedTaskPoller = CompletedTaskPoller.create(self.taskScheduler.domain);
                 startPromises.push(self.completedTaskPoller.start());

--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -16,7 +16,10 @@ di.annotate(taskRunnerFactory,
         'Rx',
         'Task.Task',
         'Task.Messenger',
-        'TaskGraph.Store'
+        'TaskGraph.Store',
+        'Services.Configuration',
+        'TaskGraph.TaskRunner.Server',
+        'consul'
     )
 );
 
@@ -30,9 +33,35 @@ function taskRunnerFactory(
     Rx,
     Task,
     taskMessenger,
-    store
+    store,
+    configuration,
+    RunnerServer,
+    Consul
 ) {
     var logger = Logger.initialize(taskRunnerFactory);
+    var url = require('url');
+    var urlObject = url.parse(configuration.get('consulUrl') || 'consul://127.0.0.1:8500');
+
+    // Create a promisified Consul interface
+    var consul = Promise.promisifyAll(Consul({
+        host: urlObject.hostname,
+        port: urlObject.port || 8500,
+        promisify: function(fn) {
+          return new Promise(function(resolve, reject) {
+            try {
+              return fn(function(err, data, res) {
+                if (err) {
+                  err.res = res;
+                  return reject(err);
+                }
+                return resolve([data, res]);
+              });
+            } catch (err) {
+              return reject(err);
+            }
+          });
+        }
+    }));
 
     /**
      * The taskRunner runs tasks which are sent over AMQP by a scheduler; a runner
@@ -410,8 +439,14 @@ function taskRunnerFactory(
     TaskRunner.prototype.stop = function() {
         var self = this;
         self.running = false;
-        return Promise.map(this.subscriptions, function() {
-            return self.subscriptions.pop().dispose();
+        return consul.agent.service.deregister({id: self.taskRunnerId})
+        .then(function() {
+            return self.gRPC.stop()
+        })
+        .then(function() {
+            return Promise.map(self.subscriptions, function() {
+                return self.subscriptions.pop().dispose();
+            })
         });
     };
 
@@ -427,7 +462,7 @@ function taskRunnerFactory(
         .then(function() {
             self.running = true;
             self.initializePipeline();
-            return [self.subscribeCancelTask(), self.subscribeRunTask()];
+            return [{}, {}];
         })
         .spread(function(cancelSubscription, runTaskSubscription) {
             self.subscriptions.push(cancelSubscription);
@@ -436,7 +471,34 @@ function taskRunnerFactory(
                 TaskRunnerId: self.taskRunnerId,
                 domain: self.domain
             });
+        })
+        .then(function() {
+            /*
+             * Start the gRPC endpoint
+             */
+            //TODO: Hack to avoid port conflicts.
+            //We should be enumerating services here to find an available port.
+            var port = 31001 + Math.round(Math.random() * 256);
+            var urlObject = url.parse(_.get(configuration.get('taskgraphConfig'),
+                                                               'url',
+                                                               'runner://127.0.0.1:' + port.toString()));
+            self.gRPC = new RunnerServer({
+                hostname: urlObject.hostname,
+                port: urlObject.port
+            });
+
+            return self.gRPC.start();
+        })
+        .then(function() {
+            return consul.agent.service.register({
+                name: 'taskgraph',
+                id: self.taskRunnerId,
+                tags: [ 'runner', self.domain ],
+                address: self.gRPC.options.hostname,
+                port: self.gRPC.options.port
+            });
         });
+
     };
 
     /** creates a new TaskRunner

--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var di = require('di');
+var grpc = require('grpc');
 
 module.exports = taskSchedulerFactory;
 di.annotate(taskSchedulerFactory, new di.Provide('TaskGraph.TaskScheduler'));
@@ -21,7 +22,8 @@ di.annotate(taskSchedulerFactory,
         'Rx.Mixins',
         'Task.Messenger',
         'Services.Configuration',
-        'TaskGraph.TaskScheduler.Server'
+        'TaskGraph.TaskScheduler.Server',
+        'consul'
     )
 );
 
@@ -39,16 +41,19 @@ function taskSchedulerFactory(
     Rx,
     taskMessenger,
     configuration,
-    SchedulerServer
+    SchedulerServer,
+    Consul
 ) {
     var logger = Logger.initialize(taskSchedulerFactory);
     var url = require('url');
     var urlObject = url.parse(configuration.get('consulUrl') || 'consul://127.0.0.1:8500');
 
     // Create a promisified Consul interface
-    var consul = Promise.promisifyAll(require('consul')({
+    var consulOpts = {
         host: urlObject.hostname,
         port: urlObject.port || 8500,
+    }
+    var consul = Consul(_.merge({}, consulOpts, {
         promisify: function(fn) {
           return new Promise(function(resolve, reject) {
             try {
@@ -160,6 +165,10 @@ function taskSchedulerFactory(
             this.handleStreamError.bind(this, 'Error at update task dependencies stream')
         );
         // Outputs to this.evaluateTaskStream
+        /*
+        BJP: Remove pollers from the pipeline for benchmarking.
+             Error cases handled by these pollers should now be handled
+             when tasks are sent to runners via gRPC
         this.createUnevaluatedTaskPollerSubscription(this.evaluateTaskStream)
         .subscribe(
             this.handleStreamDebug.bind(this, 'Triggered evaluate task event'),
@@ -170,7 +179,7 @@ function taskSchedulerFactory(
         .subscribe(
             this.handleStreamDebug.bind(this, 'Triggered evaluate graph event'),
             this.handleStreamError.bind(this, 'Error polling for tasks')
-        );
+        ); */
         // Inputs from this.evaluateGraphStream
         this.createTasksToScheduleSubscription(this.evaluateGraphStream)
         .subscribe(
@@ -577,19 +586,34 @@ function taskSchedulerFactory(
     };
 
     /**
-     * Publish a run task event with the messenger, to be picked up by any task runners
-     * within the domain.
+     * Use gRPC client to start a task on selected runner.
      *
      * @param {Object} data
      * @returns {Promise}
      * @memberOf TaskScheduler
      */
     TaskScheduler.prototype.publishScheduleTaskEvent = function(data) {
-        // TODO: Add more scheduling logic here when necessary
-        return taskMessenger.publishRunTask(this.domain, data.taskId, data.graphId)
+        var self = this;
+        return Promise.try(function() {
+            //TODO: workaround for watches not working.  Check for runners
+            // before scheduling
+            if (!self.runners || !self.runners.length) {
+                return _getRunnerServices.call(self);
+            }
+        })
         .then(function() {
+            if (!self.runners || !self.runners.length) {
+                throw new Error('no runner available for task: ' + data.taskId);
+            }
+            var runner = self.runners.next();
+            return runner.client.runTask({
+                taskId: data.taskId,
+                graphId: data.graphId
+            })
+        })
+        .then(function(response) {
             return data;
-        });
+        });  
     };
 
     /**
@@ -717,7 +741,13 @@ function taskSchedulerFactory(
             
             return self.gRPC.start();
         })
+        .then(_getRunnerServices.bind(self))
         .then(function() {
+            // TODO: figure out why watches aren't working
+            //self.watch = consul.watch({ method: consul.agent.service.list });
+
+            // TODO: What do we do about lost services???
+            //self.watch.on('change', _getRunnerServices.bind(self));
             return consul.agent.service.register({
                 name: 'taskgraph',
                 id: self.schedulerId,
@@ -727,6 +757,108 @@ function taskSchedulerFactory(
             });
         });
     };
+
+    /**
+     * Private function that wraps an array in a circular iterator.  This is used
+     * for convenient round-robin scheduling.
+     *
+     * @param {Object} Array to iterate
+     * @returns {Object} Iterator
+     * @memberOf TaskScheduler
+     */
+    function _circularIterator(array) {
+        var index = 0;
+        var arrayLength;
+
+        return {
+            length: array.length,
+            next: function() {
+                if (arrayLength === undefined) {
+                    // first use
+                    arrayLength = array.length;
+                } else if (arrayLength !== array.length) {
+                    // array length has changed, reset index
+                    arrayLength = array.length;
+                    index = 0;
+                }
+                var next = array[index];
+                index == (index + 1) % array.length;
+                return next;
+            }
+        };
+    }
+
+    /**
+     * Private function used to decorate gRPC client methods.
+     * This adds Promise handling and automatic JSON parsing while
+     * retaining the general rpc method semantics (no need to call
+     * explicit RPC method wrapper e.g. runRpc(client, 'method'))
+     *
+     * @param {Object} gRPC client object
+     * @param {String} Name of method to decorate
+     * @memberOf TaskScheduler
+     */
+    function _decorateRpc(client, method) {
+        var rpcMethod = client[method];
+        var wrappedMethod = function() {
+            var args = Array.prototype.slice.call(arguments);
+            var self = this;
+            return new Promise(function(resolve, reject) {
+                args.push(function(err, result) {
+                    if (err) {
+                        return reject(err);
+                    }
+                    try {
+                        var response = JSON.parse(result.response);
+                        return resolve(response);
+                    } catch(e) {
+                        return reject(e);
+                    }
+                })
+                rpcMethod.apply(self, args);
+            });
+        }
+        client[method] = wrappedMethod;
+    }
+
+    /**
+     * Private function used to discover available runner services.
+     *
+     * @returns {Promise}
+     * @memberOf TaskScheduler
+     */
+    function _getRunnerServices() {
+        var self = this;
+        var proto; 
+
+        return Promise.try(function() {
+            proto = grpc.load(__dirname + '/../runner.proto').runner;
+            return consul.agent.service.list()
+        })
+        .then(function(services) {
+            // filter for taskgraph runners in our domain
+            return _(services[0])
+            .filter({ Service: 'taskgraph', Tags: [ 'runner', self.domain ] })
+            .value();
+        })
+        .each(function(service) {
+            // instantiate a gRPC client for each runner
+            // then decorate all rpc client methods
+            logger.debug('Found runner ' + service.ServiceName + ':' + service.ServiceID);
+            service.client = new proto.Runner(service.Address + ':' + service.Port,
+                                              grpc.credentials.createInsecure());
+            _.forEach(proto.Runner.service.children, function(child) {
+                if (child.className === 'Service.RPCMethod') {
+                    _decorateRpc(service.client, child.name);
+                }
+            })
+        })
+        .tap(function(services) {
+            // store runners in a circular iterator for convenient
+            // round-robin scheduling
+            self.runners = _circularIterator(services);
+        })
+    }
 
     /**
      * Clean up any messenger subscriptions. Stop polling for expired leases.
@@ -741,6 +873,8 @@ function taskSchedulerFactory(
         if (self.leasePoller) {
             self.leasePoller.stop();
         }
+        // TODO: Restore this code when watches are fixed
+        //self.watch.end();
         return consul.agent.service.deregister({id: self.schedulerId})
         .then(function() {
             return self.gRPC.stop();

--- a/runner.proto
+++ b/runner.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package runner;
+
+service Runner {
+  rpc runTask (task) returns (Reply) {}
+  rpc cancelTask (task) returns (Reply) {}
+}
+
+
+message task {
+  string taskId = 1;
+  string graphId = 2;
+}
+
+message Reply {
+  string response = 1;
+}

--- a/spec/lib/task-scheduler-spec.js
+++ b/spec/lib/task-scheduler-spec.js
@@ -12,6 +12,8 @@ describe('Task Scheduler', function() {
     var Constants;
     var Promise;
     var Rx;
+    var schedulerServer;
+    var grpc;
 
     /*
      * Helper methods to test inner stream creation methods.
@@ -57,6 +59,24 @@ describe('Task Scheduler', function() {
         };
     };
 
+    function mockConsul() {
+        return {
+            agent: {
+                service: {
+                    list: sinon.stub().resolves({}),
+                    register: sinon.stub().resolves({}),
+                    deregister: sinon.stub().resolves({})
+                }
+            }
+        }
+    }
+
+    function mockGrpc() {
+        return {
+            start: sinon.stub().resolves({}),
+            stop: sinon.stub().resolves({})
+        }
+    }
 
     before(function() {
         var di = require('di');
@@ -68,7 +88,10 @@ describe('Task Scheduler', function() {
             tasks.injectables,
             require('../../lib/task-scheduler'),
             require('../../lib/lease-expiration-poller'),
-            require('../../lib/rx-mixins')
+            require('../../lib/rx-mixins'),
+            require('../../api/rpc/scheduler/index.js'),
+            helper.di.simpleWrapper(mockConsul, 'consul'),
+            helper.di.simpleWrapper(mockGrpc, 'grpc')
         ]));
         assert = helper.injector.get('Assert');
         Constants = helper.injector.get('Constants');
@@ -79,6 +102,8 @@ describe('Task Scheduler', function() {
         store = helper.injector.get('TaskGraph.Store');
         Rx = helper.injector.get('Rx');
         Promise = helper.injector.get('Promise');
+        schedulerServer = helper.injector.get('TaskGraph.TaskScheduler.Server');
+        grpc = helper.injector.get('grpc')();
         this.sandbox = sinon.sandbox.create();
     });
 
@@ -92,7 +117,9 @@ describe('Task Scheduler', function() {
             start: sinon.stub(),
             stop: sinon.stub()
         });
-    });
+        this.sandbox.stub(schedulerServer.prototype, 'start').resolves({});
+        this.sandbox.stub(schedulerServer.prototype, 'stop').resolves({});
+   });
 
     afterEach(function() {
         this.sandbox.restore();
@@ -164,6 +191,7 @@ describe('Task Scheduler', function() {
             this.sandbox.stub(taskScheduler, 'subscribeRunTaskGraph').resolves(stub);
             this.sandbox.stub(taskScheduler, 'subscribeTaskFinished').resolves(stub);
             this.sandbox.stub(taskScheduler, 'subscribeCancelGraph').resolves(stub);
+
             return taskScheduler.start()
             .then(function() {
                 expect(taskScheduler.running).to.equal(true);
@@ -254,13 +282,23 @@ describe('Task Scheduler', function() {
         });
 
         it('publishScheduleTaskEvent should publish a run task event', function() {
-            this.sandbox.stub(taskMessenger, 'publishRunTask').resolves({});
+            var runnerClient = {
+                client: {
+                    runTask: function(){}
+                }
+            };
+            var runners = {
+                length: 1,
+                next: function(){ return runnerClient }
+            };
+            taskScheduler.runners = runners;
+            this.sandbox.spy(runnerClient.client, 'runTask');
             var data = { taskId: 'testtaskid', graphId: 'testgraphid' };
             return taskScheduler.publishScheduleTaskEvent(data)
             .then(function() {
-                expect(taskMessenger.publishRunTask).to.have.been.calledOnce;
-                expect(taskMessenger.publishRunTask)
-                    .to.have.been.calledWith(taskScheduler.domain, 'testtaskid', 'testgraphid');
+                expect(runnerClient.client.runTask).to.have.been.calledOnce;
+                expect(runnerClient.client.runTask)
+                    .to.have.been.calledWith(data);
             });
         });
 
@@ -338,6 +376,7 @@ describe('Task Scheduler', function() {
 
                 taskScheduler = TaskScheduler.create();
                 taskScheduler.running = true;
+                taskScheduler.gRPC = grpc;
 
                 this.sandbox.stub(taskScheduler, 'findReadyTasks');
                 this.sandbox.stub(taskScheduler, 'handleScheduleTaskEvent');
@@ -454,6 +493,7 @@ describe('Task Scheduler', function() {
 
             taskScheduler = TaskScheduler.create();
             taskScheduler.running = true;
+            taskScheduler.gRPC = grpc;
 
             observable = taskScheduler.createUpdateTaskDependenciesSubscription(
                 taskHandlerStream,
@@ -546,6 +586,7 @@ describe('Task Scheduler', function() {
             checkGraphFinishedStream = new Rx.Subject();
             taskScheduler = TaskScheduler.create();
             taskScheduler.running = true;
+            taskScheduler.gRPC = grpc;
             this.sandbox.stub(taskScheduler, 'checkGraphSucceeded');
             this.sandbox.stub(taskScheduler, 'failGraph');
         });


### PR DESCRIPTION
* Register task runners with consul agent
* Discover runner services when starting scheduler services.
* Replace messenger service with gRPC for task scheduling.
* Disable unevaluated task pollers.