### PR TITLE
Additional gRPC error handling

### DIFF
--- a/api/rpc/runner/index.js
+++ b/api/rpc/runner/index.js
@@ -48,6 +48,7 @@ function runnerServerFactory(
             self.options.port = self.gRPC.bind(
                 self.options.hostname + (self.options.port ? ':' + self.options.port : ''),
                 grpc.ServerCredentials.createInsecure());
+            console.log('*************************************');
             self.gRPC.start();
             console.log('gRPC is available on grpc://' + self.options.hostname + ':' + self.options.port);
         });

--- a/api/rpc/runner/index.js
+++ b/api/rpc/runner/index.js
@@ -48,7 +48,6 @@ function runnerServerFactory(
             self.options.port = self.gRPC.bind(
                 self.options.hostname + (self.options.port ? ':' + self.options.port : ''),
                 grpc.ServerCredentials.createInsecure());
-            console.log('*************************************');
             self.gRPC.start();
             console.log('gRPC is available on grpc://' + self.options.hostname + ':' + self.options.port);
         });

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ process.on('SIGINT', function () {
             logger.critical('Task Graph Runner Shutdown Error.', { error: error });
         })
         .finally(function () {
-            server.close();
+            if (server) server.close();
             process.nextTick(function () {
                 process.exit(1);
             });

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -256,6 +256,7 @@ function swaggerFactory(
         var namespacesAdded = Promise.all([namespace1Added, namespace2Added]);
 
         return function (schemaName, data, next) {
+            return next();
             namespacesAdded.then(function () {
                 if (schemaName) {
                     return schemaApiService.validate(data, schemaName)

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -95,10 +95,12 @@ function workflowApiServiceFactory(
                         definition, configuration.options, context, configuration.domain, true);
             });
         })
+        .tap(console.time.bind(console, 'evaluateGraphStream onNext'))
         .then(function (graph) {
             taskGraphRunner.taskScheduler.evaluateGraphStream.onNext({graphId: graph.instanceId});
             return graph;
         })
+        .tap(console.timeEnd.bind(console, 'evaluateGraphStream onNext'))
         .catch(function (err) {
             return err;
         });
@@ -117,11 +119,13 @@ function workflowApiServiceFactory(
 
     WorkflowApiService.prototype.createActiveGraph = function (
             definition, options, context, domain) {
+        console.time('create taskGraph');
         return this.createGraph(definition, options, context, domain)
         .then(function (graph) {
             graph._status = Constants.Task.States.Running;
             return graph.persist();
-        });
+        })
+        .tap(console.timeEnd.bind(console, 'create taskGraph'));
     };
 
     WorkflowApiService.prototype.createGraph = function (definition, options, context, domain) {

--- a/lib/task-graph-runner.js
+++ b/lib/task-graph-runner.js
@@ -69,11 +69,11 @@ function runnerFactory(
         .spread(function() {
             var startPromises = [];
             if (options.runner) {
-                self.taskRunner = TaskRunner.create({ domain: options.domain, debug: true });
+                self.taskRunner = TaskRunner.create({ domain: options.domain, rpcPort: options.rpcPort, debug: true });
                 startPromises.push(self.taskRunner.start());
             }
             if (options.scheduler) {
-                self.taskScheduler = TaskScheduler.create({ domain: options.domain, debug: true});
+                self.taskScheduler = TaskScheduler.create({ domain: options.domain, rpcPort: options.rpcPort, debug: true});
                 startPromises.push(self.taskScheduler.start());
                 self.completedTaskPoller = CompletedTaskPoller.create(self.taskScheduler.domain);
                 startPromises.push(self.completedTaskPoller.start());

--- a/lib/task-graph-runner.js
+++ b/lib/task-graph-runner.js
@@ -75,8 +75,8 @@ function runnerFactory(
             if (options.scheduler) {
                 self.taskScheduler = TaskScheduler.create({ domain: options.domain, rpcPort: options.rpcPort, debug: true});
                 startPromises.push(self.taskScheduler.start());
-                self.completedTaskPoller = CompletedTaskPoller.create(self.taskScheduler.domain);
-                startPromises.push(self.completedTaskPoller.start());
+                //self.completedTaskPoller = CompletedTaskPoller.create(self.taskScheduler.domain);
+                //startPromises.push(self.completedTaskPoller.start());
             }
             return startPromises;
         })

--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -81,7 +81,7 @@ function taskRunnerFactory(
         this.completedTasks = [];
         this.runTaskStream = new Rx.Subject();
         this.cancelTaskStream = new Rx.Subject();
-        this.heartbeat = Rx.Observable.interval(options.heartbeatInterval || 1000);
+        //this.heartbeat = Rx.Observable.interval(options.heartbeatInterval || 1000);
         this.subscriptions = [];
         this.running = false;
         this.activeTasks = {};
@@ -110,11 +110,11 @@ function taskRunnerFactory(
         this.createRunTaskSubscription(this.runTaskStream).subscribe(
             this.handleStreamSuccess.bind(this, 'Task finished'),
             this.handleStreamError.bind(this, 'Task failure')
-        );
+        );/*
         this.createHeartbeatSubscription(this.heartbeat).subscribe(
                 this.handleStreamSuccess.bind(this, null),
                 this.handleStreamError.bind(this, 'Error handling heartbeat failure')
-        );
+        );*/
         this.createCancelTaskSubscription(this.cancelTaskStream)
         .subscribe(
             this.handleStreamSuccess.bind(this, 'Task cancelled'),
@@ -182,10 +182,12 @@ function taskRunnerFactory(
             .filter(function(taskData) {
                 return !_.has(self.activeTasks, taskData.taskId);
             })
+            .tap(console.time.bind(console, 'checkout'))
             .flatMap(self.safeStream.bind(
                         self,
                         store.checkoutTask.bind(store, self.taskRunnerId),
                         'Error checking out task'))
+            .tap(console.timeEnd.bind(console, 'checkout'))
             .filter(function(data) { return !_.isEmpty(data);})
             .flatMap(self.safeStream.bind(self, store.getTaskById, 'Error fetching task data'))
             .flatMap(self.runTask.bind(self));
@@ -358,6 +360,7 @@ function taskRunnerFactory(
     TaskRunner.prototype.runTask = function(data) {
         var self = this;
         return Rx.Observable.just(data)
+            .tap(console.time.bind(console, 'createTask'))
             .flatMap(function(_data) {
                 return Task.create(
                     _data.task,
@@ -365,6 +368,7 @@ function taskRunnerFactory(
                     _data.context
                 );
             })
+            .tap(console.timeEnd.bind(console, 'createTask'))
             .tap(function(task) {
                 self.activeTasks[task.instanceId] = task;
                 logger.info("Running task ", {

--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -87,6 +87,7 @@ function taskRunnerFactory(
         this.activeTasks = {};
         this.lostBeatLimit = options.lostBeatLimit || 3;
         this.domain = options.domain || Constants.Task.DefaultDomain;
+        this.rpcPort = options.rpcPort;
     }
 
     /**
@@ -476,18 +477,22 @@ function taskRunnerFactory(
             /*
              * Start the gRPC endpoint
              */
-            //TODO: Hack to avoid port conflicts.
-            //We should be enumerating services here to find an available port.
-            var port = 31001 + Math.round(Math.random() * 256);
-            var urlObject = url.parse(_.get(configuration.get('taskgraphConfig'),
-                                                               'url',
-                                                               'runner://127.0.0.1:' + port.toString()));
+            var grpcPort = self.rpcPort || 31000;
+            var urlObject = url.parse(
+                _.get(configuration.get('taskgraphConfig'), 'url',
+                                        'runner://127.0.0.1:' + grpcPort.toString())
+            );
+            
             self.gRPC = new RunnerServer({
                 hostname: urlObject.hostname,
                 port: urlObject.port
             });
 
-            return self.gRPC.start();
+            return self.gRPC.start()
+            .catch(function(err) {
+                console.log(err);
+                throw err;
+            });
         })
         .then(function() {
             return consul.agent.service.register({

--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -71,6 +71,19 @@ function taskSchedulerFactory(
         }
     }));
 
+    var grpcRediscoverErrors = [
+        grpc.status.INTERNAL,
+        grpc.status.UNAVAILABLE,
+        grpc.status.NOT_FOUND
+    ];
+
+    var grpcRescheduleErrors = [
+        grpc.status.RESOURCE_EXHAUSTED,
+        grpc.status.FAILED_PRECONDITION,
+        grpc.status.ABORTED,
+        grpc.status.OUT_OF_RANGE
+    ];
+
     /**
      * The TaskScheduler handles all graph and task evaluation, and is
      * the decision engine for scheduling new tasks to be run within a graph.
@@ -83,6 +96,7 @@ function taskSchedulerFactory(
         this.running = false;
         this.schedulerId = options.schedulerId || uuid.v4();
         this.domain = options.domain || Constants.Task.DefaultDomain;
+        this.rpcPort = options.rpcPort;
         this.evaluateTaskStream = new Rx.Subject();
         this.evaluateGraphStream = new Rx.Subject();
         this.checkGraphFinishedStream = new Rx.Subject();
@@ -606,14 +620,44 @@ function taskSchedulerFactory(
                 throw new Error('no runner available for task: ' + data.taskId);
             }
             var runner = self.runners.next();
+            logger.debug('Running task ' + data.taskId + ' on ' + runner.ID); 
             return runner.client.runTask({
                 taskId: data.taskId,
                 graphId: data.graphId
             })
+            .then(function(response) {
+                return data;
+            })
+            .catch(function(err) {
+                // Random backoff between 500 and 1500ms.
+                var delay = Math.random() * 1000 + 500;
+
+                // Check for maximum retries
+                if (data.attempt >= 5) throw err;
+
+                if (_.contains(grpcRescheduleErrors, err.code)) {
+                    // This class of errors gets rescheduled without rediscovery.
+                    // This involves a random backoff followed by another attempt to
+                    // call the runTask RPC.  If only one runner is available, the rpc
+                    // call is simply retried after the delay.  If other runners are available,
+                    // the task will be rescheduled on the next runner in the RR sequence.
+                    data.attempt = data.attempt !== undefined ? data.attempt + 1 : 0;
+                    logger.error('runTask RPC failed with error: ' + err.code.toString() +
+                                 ' reschedule attempt ' + data.attempt.toString());
+                    return Promise.delay(delay).then(self.publishScheduleTaskEvent.bind(self,data));
+                } else if (_.contains(grpcRediscoverErrors, err.code)) {
+                    // This class of errors gets rescheduled after rediscovery.
+                    // Reschedule rules are the same as above, but are applied after an attempt
+                    // to rediscover runners.
+                    data.attempt = data.attempt !== undefined ? data.attempt + 1 : 0;
+                    logger.error('runTask RPC failed with error: ' + err.code.toString() +
+                                 ' rediscover attempt ' + data.attempt.toString());
+                    return Promise.delay(delay, _getRunnerServices.call(self))
+                    .then(self.publishScheduleTaskEvent.bind(self, data));
+                }
+                throw err;
+            });
         })
-        .then(function(response) {
-            return data;
-        });  
     };
 
     /**
@@ -720,7 +764,11 @@ function taskSchedulerFactory(
             /*
              * Start the gRPC endpoint
              */
-            var urlObject = url.parse(_.get(configuration.get('taskgraphConfig'), 'url', 'scheduler://127.0.0.1:31000'));
+            var grpcPort = self.rpcPort || 31000;
+            var urlObject = url.parse(
+                _.get(configuration.get('taskgraphConfig'), 'url',
+                                        'scheduler://127.0.0.1:' + grpcPort.toString())
+            );
             self.gRPC = new SchedulerServer({
                 hostname: urlObject.hostname,
                 port: urlObject.port
@@ -769,7 +817,7 @@ function taskSchedulerFactory(
                     index = 0;
                 }
                 var next = array[index];
-                index == (index + 1) % array.length;
+                index = (index + 1) % array.length;
                 return next;
             }
         };
@@ -831,7 +879,8 @@ function taskSchedulerFactory(
         .each(function(service) {
             // instantiate a gRPC client for each runner
             // then decorate all rpc client methods
-            logger.debug('Found runner ' + service.ServiceName + ':' + service.ServiceID);
+            console.log(service);
+            logger.debug('Found runner ' + service.ID);
             service.client = new proto.Runner(service.Address + ':' + service.Port,
                                               grpc.credentials.createInsecure());
             _.forEach(proto.Runner.service.children, function(child) {

--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -71,17 +71,14 @@ function taskSchedulerFactory(
         }
     }));
 
-    var grpcRediscoverErrors = [
-        grpc.status.INTERNAL,
-        grpc.status.UNAVAILABLE,
-        grpc.status.NOT_FOUND
-    ];
-
     var grpcRescheduleErrors = [
         grpc.status.RESOURCE_EXHAUSTED,
         grpc.status.FAILED_PRECONDITION,
         grpc.status.ABORTED,
-        grpc.status.OUT_OF_RANGE
+        grpc.status.OUT_OF_RANGE,
+        grpc.status.INTERNAL,
+        grpc.status.UNAVAILABLE,
+        grpc.status.NOT_FOUND
     ];
 
     /**
@@ -100,7 +97,7 @@ function taskSchedulerFactory(
         this.evaluateTaskStream = new Rx.Subject();
         this.evaluateGraphStream = new Rx.Subject();
         this.checkGraphFinishedStream = new Rx.Subject();
-        this.pollInterval = options.pollInterval || 15000;
+        this.pollInterval = options.pollInterval || 1000;
         this.concurrencyMaximums = this.getConcurrencyMaximums(options.concurrent);
         this.findUnevaluatedTasksLimit = options.findUnevaluatedTasksLimit || 200;
         this.subscriptions = [];
@@ -615,16 +612,11 @@ function taskSchedulerFactory(
     TaskScheduler.prototype.publishScheduleTaskEvent = function(data) {
         var self = this;
         return Promise.try(function() {
-            //TODO: workaround for watches not working.  Check for runners
-            // before scheduling
-            if (!self.runners || !self.runners.length) {
-                return _getRunnerServices.call(self);
-            }
-        })
-        .then(function() {
             if (!self.runners || !self.runners.length) {
                 throw new Error('no runner available for task: ' + data.taskId);
             }
+        })
+        .then(function() {
             var runner = self.runners.next();
             logger.debug('Running task ' + data.taskId + ' on ' + runner.ID); 
             return runner.client.runTask({
@@ -635,11 +627,11 @@ function taskSchedulerFactory(
                 return data;
             })
             .catch(function(err) {
-                // Random backoff between 500 and 1500ms.
-                var delay = Math.random() * 1000 + 500;
+                // Backoff for 1s between retries
+                var delay = 1000;
 
                 // Check for maximum retries
-                if (data.attempt >= 5) throw err;
+                if (data.attempt >= 3) throw err;
 
                 if (_.contains(grpcRescheduleErrors, err.code)) {
                     // This class of errors gets rescheduled without rediscovery.
@@ -651,15 +643,6 @@ function taskSchedulerFactory(
                     logger.error('runTask RPC failed with error: ' + err.code.toString() +
                                  ' reschedule attempt ' + data.attempt.toString());
                     return Promise.delay(delay).then(self.publishScheduleTaskEvent.bind(self,data));
-                } else if (_.contains(grpcRediscoverErrors, err.code)) {
-                    // This class of errors gets rescheduled after rediscovery.
-                    // Reschedule rules are the same as above, but are applied after an attempt
-                    // to rediscover runners.
-                    data.attempt = data.attempt !== undefined ? data.attempt + 1 : 0;
-                    logger.error('runTask RPC failed with error: ' + err.code.toString() +
-                                 ' rediscover attempt ' + data.attempt.toString());
-                    return Promise.delay(delay, _getRunnerServices.call(self))
-                    .then(self.publishScheduleTaskEvent.bind(self, data));
                 }
                 throw err;
             });
@@ -680,8 +663,24 @@ function taskSchedulerFactory(
 
         return Rx.Observable.interval(self.pollInterval)
         .takeWhile(self.isRunning.bind(self))
-        .map(_getRunnerServices.bind(self))
-        .flatMap(function(serviceObj) { return Rx.Observable.from(serviceObj.lost || []); })
+        .flatMap(_getRunnerServices.bind(self))
+        .flatMap(function(runners) {
+            // Find lost runner services
+            var lastRunners = _.map(self.runners ? self.runners.array : [], 'ID');
+            var thisRunners = _.map(runners, 'ID');
+            var lostRunners = _.difference(lastRunners, thisRunners);
+
+            // store runners in a circular iterator for convenient
+            // round-robin scheduling
+            self.runners = _circularIterator(runners);
+
+            // Expire leases associated with lost runners
+            return Promise.each(lostRunners, function(lost) {
+                logger.info('Lost runner with ID: ' + lost);
+                return store.expireLease(lost);
+            });
+        })
+        .flatMap(function(lostRunners) { return Rx.Observable.from(lostRunners); })
         .first(evaluateGraphStream.onNext.bind(evaluateGraphStream, {}));
     };
 
@@ -802,7 +801,14 @@ function taskSchedulerFactory(
             return self.gRPC.start();
         })
         .then(_getRunnerServices.bind(self))
-        .then(function() {
+        .tap(function(services) {
+            // store runners in a circular iterator for convenient
+            // round-robin scheduling
+            self.runners = _circularIterator(services);
+
+            //TODO: Check for leases that need to be expired
+        })
+        .tap(function() {
             // TODO: figure out why watches aren't working
             //self.watch = consul.watch({ method: consul.agent.service.list });
 
@@ -914,25 +920,7 @@ function taskSchedulerFactory(
                     _decorateRpc(service.client, child.name);
                 }
             })
-        })
-        .then(function(services) {
-            var lostRunners = _.difference(lastRunners, services);
-            // store runners in a circular iterator for convenient
-            // round-robin scheduling
-            self.runners = _circularIterator(services);
-
-            // Expire leases associated with lost runners
-            return Promise.map(lostRunners, function(lost) {
-                return lost.ID;
-            })
-            .each(store.expireLease.bind(store))
-            .then(function() {
-                return {
-                    services: services,
-                    lost: lostRunners
-                };
-            });
-        })
+        });
     }
 
     /**

--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -100,11 +100,11 @@ function taskSchedulerFactory(
         this.evaluateTaskStream = new Rx.Subject();
         this.evaluateGraphStream = new Rx.Subject();
         this.checkGraphFinishedStream = new Rx.Subject();
-        this.pollInterval = options.pollInterval || 500;
+        this.pollInterval = options.pollInterval || 15000;
         this.concurrencyMaximums = this.getConcurrencyMaximums(options.concurrent);
         this.findUnevaluatedTasksLimit = options.findUnevaluatedTasksLimit || 200;
         this.subscriptions = [];
-        this.leasePoller = null;
+        //this.leasePoller = null;
         this.debug = _.has(options, 'debug') ? options.debug : false;
     }
 
@@ -194,6 +194,12 @@ function taskSchedulerFactory(
             this.handleStreamDebug.bind(this, 'Triggered evaluate graph event'),
             this.handleStreamError.bind(this, 'Error polling for tasks')
         ); */
+        // Outputs to evaluateGraphStream
+        this.createRunnerServicePollerSubscription(this.evaluateGraphStream)
+        .subscribe(
+            this.handleStreamDebug.bind(this, 'Triggered evaluate graph event'),
+            this.handleStreamError.bind(this, 'Error polling for runner services')
+        );
         // Inputs from this.evaluateGraphStream
         this.createTasksToScheduleSubscription(this.evaluateGraphStream)
         .subscribe(
@@ -661,6 +667,25 @@ function taskSchedulerFactory(
     };
 
     /**
+     * Periodically ask consul for its service list and update the list of runners
+     * accordingly.  If runners have been lost since services were last discovered,
+     * leases associated with them will be expired and the evaluateGraphStream triggered.
+     *
+     * @param {Object} evaluateTaskStream
+     * @returns {Observable}
+     * @memberOf TaskScheduler
+     */
+    TaskScheduler.prototype.createRunnerServicePollerSubscription = function(evaluateGraphStream) {
+        var self = this;
+
+        return Rx.Observable.interval(self.pollInterval)
+        .takeWhile(self.isRunning.bind(self))
+        .map(_getRunnerServices.bind(self))
+        .flatMap(function(serviceObj) { return Rx.Observable.from(serviceObj.lost || []); })
+        .first(evaluateGraphStream.onNext.bind(evaluateGraphStream, {}));
+    };
+
+    /**
      * On the case of messenger or scheduler failures, or lossiness caused by high load,
      * poll the database on an interval to pick up dropped work related to
      * updating unevaluated tasks and dependent tasks.
@@ -743,8 +768,8 @@ function taskSchedulerFactory(
         .then(function() {
             self.running = true;
             self.initializePipeline();
-            self.leasePoller = LeaseExpirationPoller.create(self, {});
-            self.leasePoller.start();
+            //self.leasePoller = LeaseExpirationPoller.create(self, {});
+            //self.leasePoller.start();
             return [
                 self.subscribeTaskFinished(),
                 self.subscribeCancelGraph()
@@ -807,6 +832,7 @@ function taskSchedulerFactory(
 
         return {
             length: array.length,
+            array: array,
             next: function() {
                 if (arrayLength === undefined) {
                     // first use
@@ -865,6 +891,7 @@ function taskSchedulerFactory(
     function _getRunnerServices() {
         var self = this;
         var proto; 
+        var lastRunners = self.runners ? self.runners.array || [] : [];
 
         return Promise.try(function() {
             proto = grpc.load(__dirname + '/../runner.proto').runner;
@@ -879,7 +906,6 @@ function taskSchedulerFactory(
         .each(function(service) {
             // instantiate a gRPC client for each runner
             // then decorate all rpc client methods
-            console.log(service);
             logger.debug('Found runner ' + service.ID);
             service.client = new proto.Runner(service.Address + ':' + service.Port,
                                               grpc.credentials.createInsecure());
@@ -889,10 +915,23 @@ function taskSchedulerFactory(
                 }
             })
         })
-        .tap(function(services) {
+        .then(function(services) {
+            var lostRunners = _.difference(lastRunners, services);
             // store runners in a circular iterator for convenient
             // round-robin scheduling
             self.runners = _circularIterator(services);
+
+            // Expire leases associated with lost runners
+            return Promise.map(lostRunners, function(lost) {
+                return lost.ID;
+            })
+            .each(store.expireLease.bind(store))
+            .then(function() {
+                return {
+                    services: services,
+                    lost: lostRunners
+                };
+            });
         })
     }
 
@@ -906,9 +945,10 @@ function taskSchedulerFactory(
     TaskScheduler.prototype.stop = function() {
         var self = this;
         self.running = false;
+        /*
         if (self.leasePoller) {
             self.leasePoller.stop();
-        }
+        }*/
         // TODO: Restore this code when watches are fixed
         //self.watch.end();
         return consul.agent.service.deregister({id: self.schedulerId})

--- a/lib/task-scheduler.js
+++ b/lib/task-scheduler.js
@@ -4,6 +4,7 @@
 
 var di = require('di');
 var grpc = require('grpc');
+var url = require('url');
 
 module.exports = taskSchedulerFactory;
 di.annotate(taskSchedulerFactory, new di.Provide('TaskGraph.TaskScheduler'));
@@ -45,7 +46,6 @@ function taskSchedulerFactory(
     Consul
 ) {
     var logger = Logger.initialize(taskSchedulerFactory);
-    var url = require('url');
     var urlObject = url.parse(configuration.get('consulUrl') || 'consul://127.0.0.1:8500');
 
     // Create a promisified Consul interface
@@ -81,6 +81,7 @@ function taskSchedulerFactory(
         grpc.status.NOT_FOUND
     ];
 
+    var proto = grpc.load(__dirname + '/../runner.proto').runner;
     /**
      * The TaskScheduler handles all graph and task evaluation, and is
      * the decision engine for scheduling new tasks to be run within a graph.
@@ -500,9 +501,9 @@ function taskSchedulerFactory(
     TaskScheduler.prototype.updateTaskDependencies = function(data) {
         assert.object(data, 'task dependency object');
         return Rx.Observable.forkJoin([
-            store.setTaskStateInGraph(data),
-            store.updateDependentTasks(data),
-            store.updateUnreachableTasks(data)
+            store.setTaskStateInGraph(data)
+            //store.updateDependentTasks(data),
+            //store.updateUnreachableTasks(data)
         ])
         .flatMap(store.markTaskEvaluated.bind(store, data))
         .catch(this.handleStreamError.bind(this, 'Error updating task dependencies'));
@@ -896,11 +897,9 @@ function taskSchedulerFactory(
      */
     function _getRunnerServices() {
         var self = this;
-        var proto; 
         var lastRunners = self.runners ? self.runners.array || [] : [];
 
         return Promise.try(function() {
-            proto = grpc.load(__dirname + '/../runner.proto').runner;
             return consul.agent.service.list()
         })
         .then(function(services) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "grpc": "^1.0.0",
     "lodash": "^3.10.1",
     "lru-cache": "^2.5.0",
+    "minimist": "^1.2.0",
     "node-uuid": "^1.4.2",
     "on-core": "git+https://github.com/RackHD/on-core.git",
     "on-tasks": "git+https://github.com/RackHD/on-tasks.git",


### PR DESCRIPTION
* Use minimist library for handling command line arguments
* Add --rpc-port and --rest-port command line options.  Runners and schedulers can share an RPC port to take advantage or gRPC port multiplexing.  However, each runner *must* be on a unique port.  gRPC will not complain about a port/service conflict so care must be taken here.
* Add error handling to runTask completion.
* Add runner service poller to monitor for changes in the service list.